### PR TITLE
Removed the * from secret searches that end with the search character…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 .vscode/launch.json
 .slack-slurp.yaml
-*.txt
-*.json
-.gitattributes

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode/launch.json
 .slack-slurp.yaml
+*.txt
+*.json
+.gitattributes

--- a/pkg/slurp/slurp.go
+++ b/pkg/slurp/slurp.go
@@ -316,7 +316,7 @@ func (s Slurper) GetSecretsAsync(detectrs ...detectors.Detector) (chan SecretRes
 			keywords := detector.Keywords()
 			for _, keyword := range keywords {
 				var searchString = keyword
-				var re = regexp.MustCompile(`-|_|.`)
+				var re = regexp.MustCompile(`(-|\.|_)$`)
 				if !re.MatchString(keyword) {
 					searchString = searchString + "*"
 				}

--- a/pkg/slurp/slurp.go
+++ b/pkg/slurp/slurp.go
@@ -311,16 +311,15 @@ func (s Slurper) GetSecretsAsync(detectrs ...detectors.Detector) (chan SecretRes
 	}
 
 	go func() {
+		nonStarSearchableRe := regexp.MustCompile(`(-|\.|_)$`)
 		for _, detector := range selectedDetectors {
 			var err error
 			keywords := detector.Keywords()
 			for _, keyword := range keywords {
-				var searchString = keyword
-				var re = regexp.MustCompile(`(-|\.|_)$`)
-				if !re.MatchString(keyword) {
-					searchString = searchString + "*"
+				if !nonStarSearchableRe.MatchString(keyword) {
+					keyword = keyword + "*"
 				}
-				messageChan, err2Chan := s.SearchMessagesAsync(fmt.Sprintf("%s", searchString))
+				messageChan, err2Chan := s.SearchMessagesAsync(keyword)
 
 			Loop:
 				for {

--- a/pkg/slurp/slurp.go
+++ b/pkg/slurp/slurp.go
@@ -315,7 +315,12 @@ func (s Slurper) GetSecretsAsync(detectrs ...detectors.Detector) (chan SecretRes
 			var err error
 			keywords := detector.Keywords()
 			for _, keyword := range keywords {
-				messageChan, err2Chan := s.SearchMessagesAsync(fmt.Sprintf("%s*", keyword))
+				var searchString = keyword
+				var re = regexp.MustCompile(`-|_|.`)
+				if !re.MatchString(keyword) {
+					searchString = searchString + "*"
+				}
+				messageChan, err2Chan := s.SearchMessagesAsync(fmt.Sprintf("%s", searchString))
 
 			Loop:
 				for {


### PR DESCRIPTION
… of _, -, or ., as Slack doesn't return results when the wildcard is applied after these special characters. This

now supports Slack, Dropbox, and Github tokens.